### PR TITLE
handle the version of binutils (take2)

### DIFF
--- a/main.c
+++ b/main.c
@@ -314,7 +314,7 @@ static void disassemble_and_rewrite(char *code, size_t code_size, int mem_prot)
 	assert(!mprotect(code, code_size, PROT_WRITE | PROT_READ | PROT_EXEC));
 	disassemble_info disasm_info = { 0 };
 #ifdef NEW_DIS_ASM
-	init_disassemble_info(&disasm_info, &s, NULL, do_rewrite);
+	init_disassemble_info(&disasm_info, &s, (fprintf_ftype) printf, do_rewrite);
 #else
 	init_disassemble_info(&disasm_info, &s, do_rewrite);
 #endif


### PR DESCRIPTION
The 3rd parameter of init_disassemble_info() in new API needs to be specify a non-null function address, which previous commit didn't address.  This commit fixes it.