### PR TITLE
Make memory map check strict

### DIFF
--- a/main.c
+++ b/main.c
@@ -366,7 +366,7 @@ static void rewrite_code(void)
 		char buf[4096];
 		while (fgets(buf, sizeof(buf), fp) != NULL) {
 			/* we do not touch stack and vsyscall memory */
-			if (((strstr(buf, "stack") == NULL) && (strstr(buf, "vsyscall") == NULL))) {
+			if (((strstr(buf, "[stack]\n") == NULL) && (strstr(buf, "[vsyscall]\n") == NULL))) {
 				int i = 0;
 				char addr[65] = { 0 };
 				char *c = strtok(buf, " ");


### PR DESCRIPTION
If the user-supplied executables or libraries include "stack" or "syscall" in the path, zpoline unintentionally skips binary-rewriting of the memory regions. This commit fixes the issue by the `strstr` constant strings to match only actual "[stack]" and "[vsyscall]" regions by adding brackets and '\n'.